### PR TITLE
Fix issue [CFG] - Commands failing in old versions of DDEV #32

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -30,7 +30,7 @@ hooks:
     - exec: "(drush status bootstrap | grep -q Successful) || (drush site-install --site-name=SummerHouse --account-name=admin --account-pass=admin --db-url=mysql://db:db@db/db -y && drush user-add-role 'administrator' admin)"
     - exec-host: "yes |ddev drush cset system.site uuid $(head -n 1 ./.settings/salt.txt)"
     - exec: "drush cr"
-    - exec-host: "([ $(ddev drush eval 'print_r(array_keys(\\Drupal::entityTypeManager()->getDefinitions()));' | grep shortcut -c) -gt 0 ] && (ddev drush entity:delete shortcut_set) || (echo 'No shortcut entities were found in your system.'))"
+    - exec: "([ $(drush eval 'print_r(array_keys(\\Drupal::entityTypeManager()->getDefinitions()));' | grep shortcut -c) -gt 0 ] && (drush entity:delete shortcut_set) || (echo 'No shortcut entities were found in your system.'))"
     - exec: "drush pmu shortcut -y"
     - exec: "drush cim -y"
     - exec: "drush cr"


### PR DESCRIPTION
Changed the drush eval command "drush eval 'print_r(array_keys(\Drupal::entityTypeManager()->getDefinitions()));'", is executed inside the container instead of the host.